### PR TITLE
Add toggle button for tag container expansion

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -138,10 +138,6 @@ a {
 .tag-button:hover {
   background-color: #131313;
 }
-
-.hidden {
-  display: none;
-}
 /* -------- */
 
 .tags-wrapper {

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -124,7 +124,6 @@ a {
 .tags-container {
   display: flex;
   flex-wrap: wrap;
-  width: max-content;
   gap: 0.75rem;
   padding: 0.4rem 0;
 }
@@ -139,4 +138,28 @@ a {
 .tag-button:hover {
   background-color: #131313;
 }
+
+.hidden {
+  display: none;
+}
 /* -------- */
+
+.tags-wrapper {
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  position: relative;
+}
+
+.tags-wrapper.collapsed .tags-container {
+  max-height: 50px;
+  overflow: hidden;
+}
+
+.toggle-tags-btn {
+  margin-bottom: 10px;
+  background: none;
+  border: none;
+  color: #4b99d1;
+  cursor: pointer;
+  font-size: 0.9em;
+}

--- a/docs/assets/js/tags.js
+++ b/docs/assets/js/tags.js
@@ -41,6 +41,9 @@ function getSortedTags(links) {
  * @returns {HTMLElement} The container element with all tag buttons
  */
 function createTagSection(sortedTags) {
+  const wrapper = document.createElement("div");
+  wrapper.classList.add("tags-wrapper", "collapsed");
+
   const tagSection = document.createElement("div");
   tagSection.classList.add("tags-container");
 
@@ -53,7 +56,31 @@ function createTagSection(sortedTags) {
     tagSection.appendChild(tagSpan);
   }
 
-  return tagSection;
+  wrapper.appendChild(tagSection);
+
+  const toggleButton = document.createElement("button");
+  toggleButton.classList.add("toggle-tags-btn");
+  toggleButton.textContent = "Show more";
+  toggleButton.addEventListener("click", function () {
+    if (wrapper.classList.contains("collapsed")) {
+      wrapper.classList.remove("collapsed");
+      toggleButton.textContent = "Show less";
+    } else {
+      wrapper.classList.add("collapsed");
+      toggleButton.textContent = "Show more";
+    }
+  });
+
+  setTimeout(() => {
+    // Hardcoded value; works for now.
+    if (tagSection.offsetHeight <= 49) {
+      toggleButton.style.display = "none";
+    }
+  }, 0);
+
+  wrapper.appendChild(toggleButton);
+
+  return wrapper;
 }
 
 /**


### PR DESCRIPTION
Introduced a toggle button to let users expand and collapse the list of tags.